### PR TITLE
Fix: performance optimizations and UI stability

### DIFF
--- a/Core/Util.lua
+++ b/Core/Util.lua
@@ -46,7 +46,7 @@ function Util:DebugQuest(questID)
 end
 
 function Util:Filter(t, pattern, inplace, asList)
-	asList = asList or true
+	if asList == nil then asList = true end
 
 	if inplace then
 		for i = #t, 1, -1 do
@@ -122,7 +122,7 @@ end
 ---@param useCache? boolean Use the cache by default
 ---@return boolean
 function Util:IsProfessionLearned(skillLineID, useCache)
-	useCache = useCache or true
+	if useCache == nil then useCache = true end
 
 	if self.professions == nil or not useCache then
 		local professions = {}

--- a/Core/WorldQuest.lua
+++ b/Core/WorldQuest.lua
@@ -23,10 +23,9 @@ function WorldQuest:Create(info)
 	if not HaveQuestRewardData(o.ID) then
 		C_TaskQuest.RequestPreloadRewardData(o.ID)
 		Util:Debug("Reward data is not available", o.ID, o:GetName(), C_TaskQuest.GetQuestTimeLeftSeconds(o.ID))
-		return
+	else
+		o:UpdateFirstCompletionBonus()
 	end
-
-	o:UpdateFirstCompletionBonus()
 
 	return o
 end
@@ -164,6 +163,7 @@ local WorldQuestList = {
 	mapCache = {},
 	questsOnMap = {},
 	isScanSessionCompleted = nil,
+	childMapsCache = {},
 }
 
 function WorldQuestList:Load(quests, resetStartTime)
@@ -294,8 +294,12 @@ function WorldQuestList:Scan(continents, isNewSession)
 	end
 
 	for mapID, shouldScan in pairs(continents) do
+		if self.childMapsCache[mapID] == nil then
+			self.childMapsCache[mapID] = C_Map.GetMapChildrenInfo(mapID, Enum.UIMapType.Zone, true)
+		end
+
 		local maps = shouldScan and mapsToScan or mapsToRemove
-		for _, map in ipairs(C_Map.GetMapChildrenInfo(mapID, Enum.UIMapType.Zone, true)) do
+		for _, map in ipairs(self.childMapsCache[mapID]) do
 			table.insert(maps, map)
 		end
 	end

--- a/UI/WarbandWorldQuestMapFrame.lua
+++ b/UI/WarbandWorldQuestMapFrame.lua
@@ -555,6 +555,7 @@ function WarbandWorldQuestPageMixin:OnShow()
 	self.dataProvider:RegisterCallback(self.dataProvider.Event.OnSizeChanged, self.QueueRefresh, self)
 	WorldMapFrame:RegisterCallback("WorldQuestsUpdate", self.OnMapUpdate, self)
 	EventRegistry:RegisterCallback("MapCanvas.MapSet", self.OnMapChanged, self)
+	Settings:RegisterCallback("maps_to_scan", self.Update, self)
 	Settings:RegisterCallback("reward_type_filters", self.Update, self)
 	Settings:RegisterCallback("group_collapsed_states", self.Update, self)
 	Settings:RegisterCallback("log_section_completed_shown", self.Update, self)
@@ -572,6 +573,7 @@ function WarbandWorldQuestPageMixin:OnHide()
 	self.dataProvider:UnregisterCallback(self.dataProvider.Event.OnSizeChanged, self)
 	WorldMapFrame:UnregisterCallback("WorldQuestsUpdate", self)
 	EventRegistry:UnregisterCallback("MapCanvas.MapSet", self)
+	Settings:UnregisterCallback("maps_to_scan", self)
 	Settings:UnregisterCallback("reward_type_filters", self)
 	Settings:UnregisterCallback("group_collapsed_states", self)
 	Settings:UnregisterCallback("log_section_completed_shown", self)
@@ -664,7 +666,9 @@ function WarbandWorldQuestPageMixin:QueueRefresh()
 
 	local function OnUpdate(self)
 		self:SetScript("OnUpdate", nil)
-		self:Refresh()
+		if not self:IsUpdateLocked() then
+			self:Refresh()
+		end
 	end
 
 	self:SetScript("OnUpdate", OnUpdate)

--- a/UI/WarbandWorldQuestSettingsButton.lua
+++ b/UI/WarbandWorldQuestSettingsButton.lua
@@ -147,7 +147,7 @@ function WarbandWorldQuestSettingsButtonMixin:Update(force)
 				return C_Map.GetMapInfo(mapID).name
 			end
 
-			Settings:CreateMenuTree("maps_to_scan", rootMenu, L["settings_maps_title"], GetMapName, true, MenuResponse.CloseAll)
+			Settings:CreateMenuTree("maps_to_scan", rootMenu, L["settings_maps_title"], GetMapName, true, MenuResponse.Refresh)
 		end
 
 		rootMenu:CreateDivider()

--- a/WarbandWorldQuest.lua
+++ b/WarbandWorldQuest.lua
@@ -218,6 +218,9 @@ do
 				[2274] = true, -- Khaz Algar
 				[1978] = false, -- Dragon Isles
 				[1550] = false, -- Shadowlands
+				[619]  = false, -- Legion
+				[875]  = false, -- Zandalar
+				[876]  = false, -- Kul Tiras
 			},
 			["reward_type_filters"] = {
 				["c:0"] = true, -- Gold

--- a/WarbandWorldQuest.lua
+++ b/WarbandWorldQuest.lua
@@ -218,6 +218,9 @@ do
 				[2274] = false, -- Khaz Algar
 				[1978] = false, -- Dragon Isles
 				[1550] = false, -- Shadowlands
+				[619]  = false, -- Legion
+				[875]  = false, -- Zandalar
+				[876]  = false, -- Kul Tiras
 			},
 			["reward_type_filters"] = {
 				["c:0"] = true, -- Gold

--- a/WarbandWorldQuest.lua
+++ b/WarbandWorldQuest.lua
@@ -185,7 +185,13 @@ do
 	end)
 
 	WarbandWorldQuest:RegisterEvent("QUEST_LOG_UPDATE", function()
-		WarbandWorldQuest:Update()
+		if not WarbandWorldQuest.updatePending then
+			WarbandWorldQuest.updatePending = true
+			C_Timer.After(0, function()
+				WarbandWorldQuest.updatePending = nil
+				WarbandWorldQuest:Update()
+			end)
+		end
 	end)
 
 	WarbandWorldQuest:RegisterEvent("QUEST_TURNED_IN", function(event, questID, xpReward, moneyReward)


### PR DESCRIPTION
 Summary

  Bug fixes and performance improvements addressing quest list stability and redundant API calls.

  Changes

  Fix: Quest list disappears/jumps when toggling Scanning Maps checkboxes
  - Root cause: Toggling a scanning map triggered Flush() on the data provider, which fired an OnSizeChanged callback
  scheduling a deferred QueueRefresh. This refresh could execute while the page's Update() was still in-flight (locked, with
   a C_Timer.After(0) pending), causing the ScrollBox to reinitialize with stale/empty data.
  - Fix: Register maps_to_scan as a direct page settings callback so the page properly rebuilds in the same notification
  cycle. Added IsUpdateLocked() guard in QueueRefresh's deferred OnUpdate handler to prevent it from running a Refresh()
  while Update() is mid-flight.

  Fix: Scanning Maps dropdown closes after each checkbox toggle
  - Changed MenuResponse.CloseAll to MenuResponse.Refresh so the menu stays open, allowing multiple maps to be toggled
  without reopening the menu each time.

  Fix: Util:Filter() and Util:IsProfessionLearned() ignore explicit false arguments
  - asList = asList or true and useCache = useCache or true always evaluate to true even when false is explicitly passed,
  because false or true is true in Lua. Changed to if asList == nil then asList = true end pattern.

  Perf: Cache C_Map.GetMapChildrenInfo() results in WorldQuestList:Scan()
  - C_Map.GetMapChildrenInfo() was called on every scan cycle for each continent. Since the map hierarchy is static, results
   are now cached in childMapsCache, eliminating redundant API calls on every QUEST_LOG_UPDATE.

  Perf: Debounce QUEST_LOG_UPDATE handler
  - QUEST_LOG_UPDATE fires multiple times in rapid succession (e.g., when completing objectives, entering zones). Previously
   each firing triggered a full WarbandWorldQuest:Update(). Now uses C_Timer.After(0) to coalesce multiple events in the
  same frame into a single update.

  Fix: Quest discarded when reward data not yet available on creation
  - WorldQuest:Create() previously returned nil (discarding the quest) if HaveQuestRewardData() was false. Now the quest is
  still created; only UpdateFirstCompletionBonus() is skipped until data is available. This prevents quests from silently
  disappearing from the list.
