### PR TITLE
[BUG] - FIX special assigment tooltips didnt show sometimes

### DIFF
--- a/Core/QuestRewards.lua
+++ b/Core/QuestRewards.lua
@@ -205,7 +205,7 @@ function QuestRewards:Summary(asList)
 				s = s .. format(" |T%d:15|t %d", info.iconFileID, amount)
 			end
 
-			local color = ITEM_QUALITY_COLORS[info.quality].color:GenerateHexColor()
+			local color = (ITEM_QUALITY_COLORS[info.quality] or ITEM_QUALITY_COLORS[1]).color:GenerateHexColor()
 			table.insert(records, 1, format(" |T%d:15|t |c%s[%s]|r x%d", info.iconFileID, color, info.name, amount))
 		elseif asList then
 			table.insert(records, 1, LFG_LIST_LOADING)
@@ -227,19 +227,25 @@ function QuestRewards:Summary(asList)
 			table.insert(records, 1, LFG_LIST_LOADING)
 		elseif asList then
 			local itemName, itemLink, itemQuality, itemLevel, _, itemType, itemSubType, _, itemEquipLoc, itemTexture = C_Item.GetItemInfo(itemID)
-			local color = ITEM_QUALITY_COLORS[itemQuality].color:GenerateHexColor()
 
-			if itemEquipLoc == "INVTYPE_NON_EQUIP_IGNORE" then
-				record = format(" |T%d:15|t |c%s[%s]|r", itemTexture, color, itemName)
+			if not itemName then
+				C_Item.RequestLoadItemDataByID(itemID)
+				table.insert(records, 1, LFG_LIST_LOADING)
 			else
-				record = format(" |T%d:15|t |c%s[%s (%s/%s)]|r", itemTexture, color, itemName, _G[itemEquipLoc], itemLevel)
-			end
+				local color = ITEM_QUALITY_COLORS[itemQuality].color:GenerateHexColor()
 
-			if itemEquipLoc == "INVTYPE_NON_EQUIP_IGNORE" or amount > 1 then
-				record = record .. format(" x%d", amount)
-			end
+				if itemEquipLoc == "INVTYPE_NON_EQUIP_IGNORE" then
+					record = format(" |T%d:15|t |c%s[%s]|r", itemTexture, color, itemName)
+				else
+					record = format(" |T%d:15|t |c%s[%s (%s/%s)]|r", itemTexture, color, itemName, _G[itemEquipLoc], itemLevel)
+				end
 
-			table.insert(records, 1, record)
+				if itemEquipLoc == "INVTYPE_NON_EQUIP_IGNORE" or amount > 1 then
+					record = record .. format(" x%d", amount)
+				end
+
+				table.insert(records, 1, record)
+			end
 		else
 			local _, _, _, itemEquipLoc, icon = C_Item.GetItemInfoInstant(itemID)
 

--- a/README.md
+++ b/README.md
@@ -1,8 +1,48 @@
 # WarbandWorldQuest
-     
+
 > Track World Quests across all your characters
 
-**WarbandWorldQuest** lets you easily monitor world quest progress and rewards for every character in your warband—no more logging in and out repeatedly!
+**WarbandWorldQuest** is a lightweight World of Warcraft addon that helps you answer a simple question fast: **which world quests are worth doing on which character right now?**
+
+Instead of logging in and out of every alt, scanning the map again, and trying to remember who already finished what, the addon puts warband-wide world quest progress and rewards in one place.
+
+## The Problems It Solves
+
+World quests become frustrating when you play multiple characters. This addon is built to remove the common pain points:
+
+- **Too much character swapping**
+  You should not have to log into every alt just to check whether a world quest is still available or already completed.
+
+- **Hard to remember who did what**
+  Once you have several characters, it becomes easy to lose track of which one has already completed a quest and which one still needs it.
+
+- **Rewards are tedious to compare**
+  If you are chasing gold, gear, reputation, or other specific rewards, manually checking every quest on every character wastes time.
+
+- **Map visibility is limited**
+  The default experience does not make it easy to see all relevant world quest information at a glance across your whole warband.
+
+- **Too much clutter from low-value quests**
+  When you only care about certain rewards, the full list can feel noisy and slow to review.
+
+## How WarbandWorldQuest Helps
+
+WarbandWorldQuest turns world quest checking into a quick overview instead of a repetitive routine:
+
+- **View your warband at a glance**
+  See world quest progress and rewards for all your characters in one place.
+
+- **Know what is already done**
+  Completed quests are clearly shown, helping you avoid duplicate checking and wasted travel.
+
+- **Spot valuable quests faster**
+  Reward-focused filtering helps surface the quests you actually care about.
+
+- **Read the map more easily**
+  Enhanced map pins improve visibility on both zone and continent maps.
+
+- **Stay organized with less noise**
+  Quests are split into active and inactive sections so important information stays easier to scan.
 
 ## Key Features
 
@@ -16,7 +56,16 @@
 - Displays completed quests on the map
 - Shows pins on continent maps for better visibility
 - Displays warband progress on map pin
-    
+
 ✔ **Organized Quest List** – World quests are sorted into two clear sections:
 - Active Quests – Displays quests matching your reward filters
 - Inactive Quests – Collapsible section for filtered-out quests
+
+## Best For
+
+This addon is especially useful if you:
+
+- play multiple characters regularly
+- want to quickly decide which alt should do a quest
+- care about specific reward types
+- want a cleaner, faster world quest review process

--- a/WarbandWorldQuest.lua
+++ b/WarbandWorldQuest.lua
@@ -218,6 +218,9 @@ do
 				[2274] = true, -- Khaz Algar
 				[1978] = false, -- Dragon Isles
 				[1550] = false, -- Shadowlands
+				[619]  = false, -- Legion
+				[875]  = false, -- Zandalar
+				[876]  = false, -- Kul Tiras
 			},
 			["reward_type_filters"] = {
 				["c:0"] = true, -- Gold

--- a/WarbandWorldQuest.lua
+++ b/WarbandWorldQuest.lua
@@ -218,6 +218,9 @@ do
 				[2274] = false, -- Khaz Algar
 				[1978] = false, -- Dragon Isles
 				[1550] = false, -- Shadowlands
+				[619]  = false, -- Legion
+				[875]  = false, -- Zandalar
+				[876]  = false, -- Kul Tiras
 			},
 			["reward_type_filters"] = {
 				["c:0"] = true, -- Gold


### PR DESCRIPTION
  - Fixes tooltip not showing for quests (notably special assignments)
  when C_Item.GetItemInfo() returns nil despite IsItemDataCachedByID()
  returning true — the nil itemQuality causes ITEM_QUALITY_COLORS[nil] to
   error, preventing tooltip:Show() from executing
  - Adds nil-safety fallback: shows "Loading..." and requests item data
  reload instead of silently erroring
  - Adds defensive fallback for currency quality in ITEM_QUALITY_COLORS
  lookup