### PR TITLE
Replace WarbandWorldQuest reset timer with hourly ticker

### DIFF
--- a/WarbandWorldQuest.lua
+++ b/WarbandWorldQuest.lua
@@ -92,17 +92,17 @@ function WarbandWorldQuest:Update(isNewScanSession)
 	if isNewScanSession then
 		WorldQuestList:Reset(GenerateClosure(self.RemoveQuestRewardsFromAllCharacters, self))
 
-		if self.resetTimer ~= nil then
-			self.resetTimer:Cancel()
-			self.resetTimer = nil
+		if self.resetTicker ~= nil then
+			self.resetTicker:Cancel()
+			self.resetTicker = nil
 		end
 	end
 
 	local changed = WorldQuestList:Scan(Settings:Get("maps_to_scan"), isNewScanSession)
 	if changed then
-		local secondsToReset = select(2, WorldQuestList:NextResetQuests()) - GetServerTime() + 60
-
-		self.resetTimer = C_Timer.NewTimer(secondsToReset, GenerateClosure(self.Update, self, true))
+		if self.resetTicker == nil then
+			self.resetTicker = C_Timer.NewTicker(3600, GenerateClosure(self.Update, self, true))
+		end
 		self.character:SetQuests(WorldQuestList:GetAllQuests())
 
 		self.warModeScanned = C_PvP.IsWarModeActive() or self.warModeScanned

--- a/WarbandWorldQuest.lua
+++ b/WarbandWorldQuest.lua
@@ -28,6 +28,7 @@ function WarbandWorldQuest:Init()
 
 	self.dataProvider = self:CreateDataProvider()
 	self:Update(true)
+	self:StartResetTicker()
 
 	for _, pin in ipairs({ WorldMap_WorldQuestPinMixin, WarbandWorldQuestPinMixin }) do
 		hooksecurefunc(pin, "OnMouseEnter", function(pin)
@@ -74,6 +75,23 @@ function WarbandWorldQuest:Init()
 	Settings:RegisterCallback("maps_to_scan", self.Update, self, true)
 end
 
+function WarbandWorldQuest:StartResetTicker()
+	if self.resetTicker ~= nil or self.resetTickerStartTimer ~= nil then
+		return
+	end
+
+	local secondsToNextHour = 3600 - (GetServerTime() % 3600)
+	if secondsToNextHour == 0 then
+		secondsToNextHour = 3600
+	end
+
+	self.resetTickerStartTimer = C_Timer.NewTimer(secondsToNextHour, function()
+		self.resetTickerStartTimer = nil
+		self:Update(true)
+		self.resetTicker = C_Timer.NewTicker(3600, GenerateClosure(self.Update, self, true))
+	end)
+end
+
 function WarbandWorldQuest:RemoveQuestRewardsFromAllCharacters(quest)
 	self.characterStore:ForEach(function(character)
 		if character.rewards[quest.ID] then
@@ -91,18 +109,10 @@ function WarbandWorldQuest:Update(isNewScanSession)
 
 	if isNewScanSession then
 		WorldQuestList:Reset(GenerateClosure(self.RemoveQuestRewardsFromAllCharacters, self))
-
-		if self.resetTicker ~= nil then
-			self.resetTicker:Cancel()
-			self.resetTicker = nil
-		end
 	end
 
 	local changed = WorldQuestList:Scan(Settings:Get("maps_to_scan"), isNewScanSession)
 	if changed then
-		if self.resetTicker == nil then
-			self.resetTicker = C_Timer.NewTicker(3600, GenerateClosure(self.Update, self, true))
-		end
 		self.character:SetQuests(WorldQuestList:GetAllQuests())
 
 		self.warModeScanned = C_PvP.IsWarModeActive() or self.warModeScanned


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- replace `WarbandWorldQuest` reset scheduling from one-shot `C_Timer.NewTimer` to an hourly ticker flow
- align the first run to the start of the next server hour, then run every 3600 seconds
- keep quest refresh behavior by invoking `Update(true)` at each hourly boundary

## Testing
- verified timer setup now computes `secondsToNextHour` from `GetServerTime()`
- verified the callback starts a recurring `C_Timer.NewTicker(3600, ...)`
- no automated test suite is configured in this repository
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-dd12379c-9cac-4b39-9937-8ff39d6235d3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-dd12379c-9cac-4b39-9937-8ff39d6235d3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

